### PR TITLE
Fix Typo on Async Lesson

### DIFF
--- a/lessons/async.md
+++ b/lessons/async.md
@@ -4,7 +4,7 @@ path: "/async"
 title: "Handling Async"
 ---
 
-We've seen one way to handle async code in React: with effects. This is most useful when you need to be reactive to your data changing or when you're setting up or tearing down a component. Some times you just need to respond someone pressing a button. This isn't hard to accomplish either. Let's make whenever someone either hits enter or whenever someone clicks the button that it search for animals. We can do this by listening for submit events on the form. Let's go do that now. In SearchParams.js
+We've seen one way to handle async code in React: with effects. This is most useful when you need to be reactive to your data changing or when you're setting up or tearing down a component. Some times you just need to respond to someone pressing a button. This isn't hard to accomplish either. Let's make whenever someone either hits enter or whenever someone clicks the button that it searches for animals. We can do this by listening for submit events on the form. Let's go do that now. In SearchParams.js
 
 ```javascript
 // inside render


### PR DESCRIPTION
Without extra 'to' sentence reads oddly. Changed search to searches.