### PR TITLE
Remove stray semicolon

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,6 @@ const App = () => {
         <header>
           <Link to="/">Adopt Me!</Link>
         </header>
-        ;
         <Router>
           <SearchParams path="/" />
           <Details path="/details/:id" />


### PR DESCRIPTION
Removes a stray semicolon from `App.js`, which is currently sitting below the header:

![image](https://user-images.githubusercontent.com/1382445/59391099-232ef900-8d28-11e9-8d04-3c24920010a9.png)