### PR TITLE
Removed accidental semicolon

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,6 @@ const App = () => {
         <header>
           <Link to="/">Adopt Me!</Link>
         </header>
-        ;
         <Router>
           <SearchParams path="/" />
           <Details path="/details/:id" />


### PR DESCRIPTION
There was a redundant semicolon that rendered between the header and the rest of the page.