### PR TITLE
fixes for Effects section

### DIFF
--- a/lessons/effects.md
+++ b/lessons/effects.md
@@ -14,11 +14,11 @@ Now any time you run this `npm run dev:mock` instead of `npm run dev` you'll get
 
 Now let's go install the client. Run `npm install @frontendmasters/pet`.
 
-In SearchParam.js:
+In SearchParams.js:
 
 ```javascript
 // at the top
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import pet, { ANIMALS } from "@frontendmasters/pet";
 
 // inside render method, below useDropdown calls
@@ -27,11 +27,10 @@ useEffect(() => {
 });
 ```
 
-- pf takes in credentials and returns an API object. You only have to give it credentials here; anywhere else you import it it'll retain the same credentials. The API response has a silly and ridiculous structure.
 - Here we're using an effect to retrieve a list of breeds from the API. An effect is run after every render (which happens after state changes.) You're going to use effects to do things like AJAX calls, modify ambient state, integrate with other libraries, and many other things. Basically it's a way to delay work until after render happens and to deal with asynchronous side effects.
 - If you're familiar with previous versions of React, effects can take the place of _most_ life cycle methods. In this case we're going to use it instead of `componentDidMount` and `componentDidUpdate`.
 
-So rather just having `dog` be the static animal, let's make that dynamic and let's make it actually save the breed it gets.
+So rather than just having `dog` be the static animal, let's make that dynamic and let's make it actually save the breed it gets.
 
 ```javascript
 // replace effect
@@ -46,8 +45,7 @@ useEffect(() => {
 ```
 
 - Due to JavaScript closures (the fact that state is preserved for various render function calls) we're able to reference updateBreeds from the outer scope. We use this to update the breed after the successful call to the petfinder API.
-- Petfinder API does weird stuff where it returns an array if there are more than one breed but just returns a string if there's only one. It's dumb.
-- The array at the end is peculiar but essential. By default, effects will run at the end of every re-render. This is problematic for us because we're updating breeds, which causes a re-render, which causes another effect, which causes another re-render, etc. What you can to prevent this spiral is give it an array at the end of variables as a second parameter. Now this effect will only happen if one of those variables changes. In this case, it will only cause the effect if `animal` changes. Which is exactly what we want.
+- The array at the end is peculiar but essential. By default, effects will run at the end of every re-render. This is problematic for us because we're updating breeds, which causes a re-render, which causes another effect, which causes another re-render, etc. What you can to prevent this spiral is give it an array of variables as a second parameter. Now this effect will only happen if one of those variables changes. In this case, it will only cause the effect if `animal` changes. Which is exactly what we want.
 - Effects are always called after the first render no matter what.
 - We have to pull the strings out of the objects from the API since the dropdown expect a list of strings, hence the map which does just that.
 
@@ -64,7 +62,7 @@ We want to console.error the messages if there's an error. Let's go turn that wa
 
 - It's useful to have ESLint bug you about taking console logs out but some times you do want them. Feel free to turn it off if it suits you.
 
-Whenever a user selects a new animal, we need to programtically update the breed. Since we put this into a custom hook, we have no way to do that. Let's go make it do that. In useDropdown.js:
+Whenever a user selects a new animal, we need to programmatically update the breed. Since we put this into a custom hook, we have no way to do that. Let's go make it do that. In useDropdown.js:
 
 ```javascript
 // update return


### PR DESCRIPTION
- keep `useState`, we still need it
- deleted explanations of nonexistent code
  - credentials
  - array/string API response
- "at the end" was redundant and a little confusing
  - and "second parameter" is more precise
- typos