### PR TITLE
small fixes for Error Boundaries lesson

### DIFF
--- a/lessons/error-boundaries.md
+++ b/lessons/error-boundaries.md
@@ -42,13 +42,14 @@ export default ErrorBoundary;
 ```
 
 - Now anything that is a child of this component will have errors caught here. Think of this like a catch block from try/catch.
-- A static method is one that can be called on the constructor. If you'd call this method like this: `ErrorBoundary.getDerivedStateFromError(error)`. This method must be static.
+- A static method is one that can be called on the constructor. You'd call this method like this: `ErrorBoundary.getDerivedStateFromError(error)`. This method must be static.
 - If you want to call an error logging service, `componentDidCatch` would be an amazing place to do that. I can recommend [Azure Monitor][azure], [Sentry][sentry], and [TrackJS][trackjs].
 
 Let's go make Details use it. Go to Details.js
 
 ```javascript
 // add import
+import ErrorBoundary from "./ErrorBoundary";
 
 // replace export
 export default function DetailsErrorBoundary(props) {
@@ -61,7 +62,7 @@ export default function DetailsErrorBoundary(props) {
 ```
 
 - Now this is totally self contained. No one rendering Details has to know that it has its own error boundary. I'll let you decide if you like this pattern or if you would have preferred doing this in App.js at the Router level. Differing opinions exist.
-- We totally could have made ErrorBoundary a bit more flexible and made it able to accept a component to display in cases of errors. In general I recommend the "WET" code rule (as opposed to [DRY][dry], lol): Write Everything Twice (or I even prefer Write Everything Thrice). In this case, we have one use case for this component, so I won't spend the extra time to make it flexible. If I used it again, I'd make it work both of those use cases, but not _every_ use case. On the third or fourth time, I'd then go back and invest the time to make it flexible.
+- We totally could have made ErrorBoundary a bit more flexible and made it able to accept a component to display in cases of errors. In general I recommend the "WET" code rule (as opposed to [DRY][dry], lol): Write Everything Twice (or I even prefer Write Everything Thrice). In this case, we have one use case for this component, so I won't spend the extra time to make it flexible. If I used it again, I'd make it work for both of those use cases, but not _every_ use case. On the third or fourth time, I'd then go back and invest the time to make it flexible.
 
 Let's make it redirect automatically after five seconds. We could do a set timeout in the `componentDidCatch` but let's do it with `componentDidUpdate` to show you how that works.
 


### PR DESCRIPTION
- grammar changes
- provided code to import `ErrorBoundary`