### PR TITLE
Context lesson changes

### DIFF
--- a/lessons/context.md
+++ b/lessons/context.md
@@ -12,9 +12,9 @@ Context (mostly) replaces Redux. Well, typically. It fills the same need as Redu
 
 Again, this is a contrived example. What we're doing here is overkill and should be accomplished via React's normal patterns. But let's check out what this looks like.
 
-Imagine if we wanted to make the search box at the top of the page appear on the search-params page and the results page and re-use that component. And we want to make that state stick between the two. This means the state has live outside of those routes. We could use Redux for it, we could React itself, or we're going to use context, to teach you what that looks like.
+Imagine if we wanted to let the user choose a simple theme for the site. And we want to make that theme stick as the user navigates across different pages. This means the state has to live outside of the route where it's selected. We could use Redux for this, we could use React itself, or we're going to use context, to teach you what that looks like.
 
-Make a new file called ThemeContext.js
+Make a new file called ThemeContext.js:
 
 ```javascript
 import { createContext } from "react";
@@ -28,9 +28,9 @@ export default ThemeContext;
 
 A Consumer is how you consume from the above provider. A Consumer accepts a function as a child and gives it the context which you can use. We won't be using the Consumer directly: a function called `useContext` will do that for us.
 
-The object provided to context is the default state it uses when it can find no Provider above it, useful if there's a chance no provider will be there and for testing. It's also use for TypeScript because TypeScript will enforce these types. Here we're giving it the shape of a `useState` call because we'll using `useState` with it. You do not have to use context with hooks; [see v4][v4] if you want to see how to do it without hooks. This example also has a more complicated data shape. This example is a lot more simple. If you wanted a more complicated data shape, you'd replace `"green"` with an object full of other properties.
+The object provided to context is the default state it uses when it can find no Provider above it, useful if there's a chance no provider will be there and for testing. It's also useful for TypeScript because TypeScript will enforce these types. Here we're giving it the shape of a `useState` call because we'll using `useState` with it. You do not have to use context with hooks; [see v4][v4] if you want to see how to do it without hooks. That example also has a more complicated data shape. This example is a lot more simple. If you wanted a more complicated data shape, you'd replace `"green"` with an object full of other properties.
 
-Now we're going to make all the buttons' background color in the app be governed by the theme. First let's go to App.js
+Now we're going to make all the buttons' background color in the app be governed by the theme. First let's go to App.js:
 
 ```javascript
 // import useState and ThemeContext
@@ -51,10 +51,11 @@ const theme = useState("darkblue");
 - Note that the theme will only be available _inside_ of this provider. So if we only wrapped the `<Details>` route with the Provider, that context would not be available inside of `<SearchParams />`.
 - Side note: if your context is _read only_ (meaning it will _never change_) you actually can skip wrapping your app in a Provider.
 
-Next let's go to `SearchParams.js`
+Next let's go to `SearchParams.js`:
 
 ```javascript
 // import at top
+import React, { useState, useEffect, useContext } from "react";
 import ThemeContext from "./ThemeContext";
 
 // top of SearchParams function body
@@ -86,8 +87,9 @@ import ThemeContext from "./ThemeContext";
 
 - This is how you use context inside of a class component.
 - Remember you cannot use hooks inside class components at all. This is why we're using the `Consumer` from `ThemeContext`. Functionally this works the same way though.
+- We'll create the `toggleModal` handler in the next section.
 
-Lastly let's go make the theme change-able. Head back to SearchParams.js.
+Lastly let's go make the theme changeable. Head back to SearchParams.js.
 
 ```javascript
 // also grab setTheme
@@ -109,9 +111,9 @@ const [theme, setTheme] = useContext(ThemeContext);
 </label>;
 ```
 
-- This looks relatively similar to hooks, right? I should because it works the same!
+- This looks relatively similar to hooks, right? It should because it works the same!
 - Now try changing the theme and navigating to a pet page. Notice the theme is consistent! The theme is kept between pages because it's kept at the App level and App is never unmounted so its state persists between route changes.
-- You can multiple layers of context. If I wrapped SearchParams in its own `Provider` (in addition to the one that already exists), the SearchParams context would read from that because it's the closet one whereas Details would read from the top level one because it's the only one.
+- You can have multiple layers of context. If I wrapped SearchParams in its own `Provider` (in addition to the one that already exists), the SearchParams context would read from that because it's the closest one whereas Details would read from the top level one because it's the only one.
 
 That's it for context! Something like theming would be perfect for context. It's for app-level data. Everything else should be boring-ol' state.
 


### PR DESCRIPTION
- replaced "search box" text from v4 example
  - with text that explains the v5 example
- added missing `import`
- explained appearance of `toggleModal`
- typos, grammar