### PR TITLE
noThrow added to Redirect in ErrorBoundary

### DIFF
--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -20,7 +20,7 @@ class ErrorBoundary extends Component {
   }
   render() {
     if (this.state.redirect) {
-      return <Redirect to="/" />;
+      return <Redirect to="/" noThrow />;
     }
 
     if (this.state.hasError) {


### PR DESCRIPTION
In my case in a dev env with missing noThrow <Redirect> was throwing an error and not redirecting. I found solution here: https://github.com/reach/router/issues/100#issuecomment-415424987