### PR TITLE
Fix relative paths bug for SSR

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,15 @@ import App from "../src/App";
 
 const PORT = process.env.PORT || 3000;
 
-const html = fs.readFileSync("dist/index.html").toString();
+const html = fs.readFileSync("dist/index.html")
+  .toString()
+  // when making a request to /details/:id we want the server to reply with
+  // <script src="/dist/ClientApp.js"> and <link .. href="/dist/style.css">
+  // instead of <script src="dist/ClientApp.js"> which would make a request for 
+  // a JavaScript file to <server>:<port>/details/dist/ClientApp.js (which will
+  // respond with the index.html file instead of our static resources)
+  // the correct url will always make the request to /dist/<resource>
+  .replace(/"dist/g, '"/dist');
 
 const parts = html.split("not rendered");
 


### PR DESCRIPTION
In your frontendmasters SSR chapter, last video (00:03:58) you encounter a bug. You get a `index.html` version of the `/details:id` page, but with no styling. That's because when you refreshed the page it made a request to the static resources, but with a relative path (`localhost:3000/details/dist/ClientApp.js`). Since it didn't match the `/dist` route of Express, it will always match the default (React render/stream one).

In this commit I just replace the `"dist` with `"/dist` so it will always point to the correct static resource.