### PR TITLE
Fix a typo on the theme label htmlFor

### DIFF
--- a/src/SearchParams.js
+++ b/src/SearchParams.js
@@ -53,7 +53,7 @@ const SearchParams = () => {
         </label>
         <AnimalDropdown />
         <BreedDropdown />
-        <label htmlFor="location">
+        <label htmlFor="theme">
           Theme
           <select
             value={theme}


### PR DESCRIPTION
 - This PR is intended to fix a typo on the theme label htmlFor. 
     

> I replace `location` with `theme`
