### PR TITLE
Update effects.md

### DIFF
--- a/lessons/effects.md
+++ b/lessons/effects.md
@@ -10,7 +10,7 @@ Since this Petfinder is a real service and we don't want to hammer their API, we
 
 `"dev:mock": "cross-env PET_MOCK=mock npm run dev",`.
 
-Now any time you run this `npm run dev:mock` instead of `npm run dev` you'll get mock data and not hit the API. This will work offline and if the API is down or taking too long.
+Now any time you run this `npm run dev:mock` instead of `npm run dev` you'll get mock data and not hit the API. This will work offline and if the API is down or taking too long (before running this, you many need to delete existing .cache and .dist folders to allow building in the mock mode).
 
 Now let's go install the client. Run `npm install @frontendmasters/pet`.
 


### PR DESCRIPTION
The script `"dev:mock": "cross-env PET_MOCK=mock npm run dev"`, sometimes does not make the app run in mock mode. This is because Parcel builds the app from existing .cache and .dist directories. Removing these folders and running `npm run dev:mock` fixes the problem.

Brian gives the same fix in his video lessons