### PR TITLE
fix replace to replace all

### DIFF
--- a/src/useDropdown.js
+++ b/src/useDropdown.js
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 
 const useDropdown = (label, defaultState, options) => {
   const [state, updateState] = useState(defaultState);
-  const id = `use-dropdown-${label.replace(" ", "").toLowerCase()}`;
+  // if the replace pattern is a string only the first occurrence will be replaced
+  // so to replace all use a regex with g flag
+  const id = `use-dropdown-${label.replace(/ /g, "").toLowerCase()}`;
   const Dropdown = () => (
     <label htmlFor={id}>
       {label}


### PR DESCRIPTION
Greetings,

Replace was replacing only the first occurrence, but it was meant to replace all, as per the example explained in the v5 course.

It's a really common mistake; we forget about the quirky replace all the time!
So I updated the code and added comments to help others avoid this mistake
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace

Best Regards,
Ahmed