### PR TITLE
Fixed replacing of spaces in string

### DIFF
--- a/src/useDropdown.js
+++ b/src/useDropdown.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 const useDropdown = (label, defaultState, options) => {
   const [state, updateState] = useState(defaultState);
-  const id = `use-dropdown-${label.replace(" ", "").toLowerCase()}`;
+  const id = `use-dropdown-${label.replace(/ /gm, "").toLowerCase()}`;
   const Dropdown = () => (
     <label htmlFor={id}>
       {label}


### PR DESCRIPTION
The replace() like it was before wouldn't replace all spaces of the string (it would only replace the first one in the string) in order to replace all, you would need to use replaceAll() but replace() using regex is faster.