### PR TITLE
Update ESLint config file to remove deprecated extend.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
     "prettier",
-    "prettier/react"
   ],
   "rules": {
     "react/prop-types": 0,


### PR DESCRIPTION

In `.eslintrc.json` file when "prettier/react" is included, it gives an error below:
`ESLint: 7.20.0  Error: Cannot read config file: ...../node_modules/eslint-config-prettier/react.js`

As it is noted in **Version 8.0.0 (2021-02-21)** of  **eslint-config-prettier**, there is not need to write the specific library extend name for prettier.

So, instead of this, 
```
"extends": [
    "eslint:recommended",
    "plugin:import/errors",
    "plugin:react/recommended",
    "plugin:jsx-a11y/recommended",
    "prettier",
    "prettier/react"
  ]
```
We must write, like that,
```
"extends": [
    "eslint:recommended",
    "plugin:import/errors",
    "plugin:react/recommended",
    "plugin:jsx-a11y/recommended",
    "prettier"
  ]
```

Referance:
https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21